### PR TITLE
Fix R CMD check output capturing

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -139,7 +139,7 @@ func execCommand(command string, showOutput bool, returnOutput bool, envs []stri
 	_, errWriteString := file.WriteString(outStr)
 	checkError(errWriteString)
 
-	return outStr, nil
+	return outStr, errCombinedOutput
 }
 
 func tsort(graph map[string][]string) (resultOrder []string) {


### PR DESCRIPTION
This fixes a situation when in some cases, after R CMD check fails, the command output is not captured properly.