### PR TITLE
Fix processing `renv.lock` files generated by `renv`

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,15 +10,15 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
-      - darwin
-      - solaris
-      - freebsd
+      # - windows
+      # - darwin
+      # - solaris
+      # - freebsd
     goarch:
       - amd64
-      - arm
-      - arm64
-      - ppc64
+      # - arm
+      # - arm64
+      # - ppc64
     ldflags:
       - -s -w
       - -X go.szostok.io/version.version={{.Version}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,15 +10,15 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      # - windows
-      # - darwin
-      # - solaris
-      # - freebsd
+      - windows
+      - darwin
+      - solaris
+      - freebsd
     goarch:
       - amd64
-      # - arm
-      # - arm64
-      # - ppc64
+      - arm
+      - arm64
+      - ppc64
     ldflags:
       - -s -w
       - -X go.szostok.io/version.version={{.Version}}

--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -111,6 +111,10 @@ func getDepsFromPackagesFiles(
 		"https://cloud.r-project.org/src/contrib/PACKAGES", make(map[string]string),
 	)
 	cranPackagesFile := locksmith.ProcessPackagesFile(cranPackagesContent)
+	log.Info(
+		"Dependencies for packages with Repository renv.lock field equal to any of ", erroneousRepositoryNames,
+		" will be determined based on PACKAGES file from CRAN.",
+	)
 	for _, repositoryName := range erroneousRepositoryNames {
 		for packageName := range rPackages {
 			// Check if packages downloaded successfully.
@@ -188,7 +192,7 @@ func getDepsFromDescriptionFiles(
 					filteredDependencies = append(filteredDependencies, dependency.DependencyName)
 				}
 			}
-			log.Info(packageName, " → ", filteredDependencies)
+			log.Debug(packageName, " → ", filteredDependencies)
 			packageDependencies[packageName] = filteredDependencies
 		}
 	}

--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -105,11 +105,6 @@ func getDepsFromPackagesFiles(
 			}
 		}
 	}
-	log.Debug("Length = ", len(erroneousRepositoryNames))
-	if len(erroneousRepositoryNames) == 0 {
-		return
-	}
-	log.Debug("Len = ", len(erroneousRepositoryNames))
 
 	// Iterate through packages which have the repository name set to one which is not defined
 	// in the renv.lock header. For these packages we'll use PACKAGES file from CRAN to determine

--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -89,6 +89,7 @@ func getDepsFromPackagesFiles(
 					"Skipping package ", packageName, " because it hasn't been",
 					" downloaded properly.",
 				)
+				continue
 			}
 			// Retrieve information about package dependencies from the PACKAGES file.
 			// The PACKAGES file is downloaded from the same repository as the package
@@ -115,26 +116,25 @@ func getDepsFromPackagesFiles(
 		"Dependencies for packages with Repository renv.lock field equal to any of ", erroneousRepositoryNames,
 		" will be determined based on PACKAGES file from CRAN.",
 	)
-	for _, repositoryName := range erroneousRepositoryNames {
-		for packageName := range rPackages {
-			// Check if packages downloaded successfully.
-			var packageRepository string
-			downloadedPackage, ok := downloadedPackages[packageName]
-			if ok {
-				packageRepository = downloadedPackage.PackageRepository
-			} else {
-				log.Warn(
-					"Skipping package ", packageName, " because it hasn't been",
-					" downloaded properly.",
-				)
-			}
-			if packageRepository == repositoryName {
-				packageDeps := getPackageDepsFromPackagesFile(
-					packageName, cranPackagesFile, downloadedPackages,
-				)
-				log.Debug(packageName, " → ", packageDeps)
-				packageDependencies[packageName] = packageDeps
-			}
+	for packageName := range rPackages {
+		// Check if packages downloaded successfully.
+		var packageRepository string
+		downloadedPackage, ok := downloadedPackages[packageName]
+		if ok {
+			packageRepository = downloadedPackage.PackageRepository
+		} else {
+			log.Warn(
+				"Skipping package ", packageName, " because it hasn't been",
+				" downloaded properly.",
+			)
+			continue
+		}
+		if stringInSlice(packageRepository, erroneousRepositoryNames) {
+			packageDeps := getPackageDepsFromPackagesFile(
+				packageName, cranPackagesFile, downloadedPackages,
+			)
+			log.Debug(packageName, " → ", packageDeps)
+			packageDependencies[packageName] = packageDeps
 		}
 	}
 }

--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -105,9 +105,12 @@ func getDepsFromPackagesFiles(
 			}
 		}
 	}
+	log.Debug("Length = ", len(erroneousRepositoryNames))
 	if len(erroneousRepositoryNames) == 0 {
 		return
 	}
+	log.Debug("Len = ", len(erroneousRepositoryNames))
+
 	// Iterate through packages which have the repository name set to one which is not defined
 	// in the renv.lock header. For these packages we'll use PACKAGES file from CRAN to determine
 	// their dependencies.

--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -79,7 +79,7 @@ func getDepsFromPackagesFiles(
 		// Go through the list of packages from renv.lock, and add information to the output data structure
 		// about dependencies but only those which were downloaded from this repository.
 		for packageName := range rPackages {
-			// Check if packages downloaded successfully.
+			// Check if package downloaded successfully.
 			var packageRepository string
 			downloadedPackage, ok := downloadedPackages[packageName]
 			if ok {
@@ -105,6 +105,9 @@ func getDepsFromPackagesFiles(
 			}
 		}
 	}
+	if len(erroneousRepositoryNames) == 0 {
+		return
+	}
 	// Iterate through packages which have the repository name set to one which is not defined
 	// in the renv.lock header. For these packages we'll use PACKAGES file from CRAN to determine
 	// their dependencies.
@@ -117,7 +120,7 @@ func getDepsFromPackagesFiles(
 		" will be determined based on PACKAGES file from CRAN.",
 	)
 	for packageName := range rPackages {
-		// Check if packages downloaded successfully.
+		// Check if package downloaded successfully.
 		var packageRepository string
 		downloadedPackage, ok := downloadedPackages[packageName]
 		if ok {

--- a/cmd/dependencies_test.go
+++ b/cmd/dependencies_test.go
@@ -42,6 +42,11 @@ Depends: package4
 Package: package4
 Version: 2.0.0
 `
+	case url == "https://cloud.r-project.org/src/contrib/PACKAGES":
+		return 200, 0, `Package: package5
+Version: 1.2.3
+Imports: package1
+`
 	}
 	return 200, 0, ""
 }
@@ -54,19 +59,22 @@ func Test_getDepsFromPackagesFiles(t *testing.T) {
 	rPackages["package2"] = Rpackage{"package2", "", "", "Repository1", "", "", []string{}, "", "", "", "", "", ""}
 	rPackages["package3"] = Rpackage{"package3", "", "", "Repository2", "", "", []string{}, "", "", "", "", "", ""}
 	rPackages["package4"] = Rpackage{"package4", "", "", "Repository2", "", "", []string{}, "", "", "", "", "", ""}
+	rPackages["package5"] = Rpackage{"package5", "", "", "UndefinedRepository", "", "", []string{}, "", "", "", "", "", ""}
 	downloadedPackages["package1"] = DownloadedPackage{"", "", "Repository1", "/tmp/scribe/downloaded_packages/package_archives/package1_1.0.0.tar.gz"}
 	downloadedPackages["package2"] = DownloadedPackage{"", "", "Repository1", "/tmp/scribe/downloaded_packages/package_archives/package2_1.0.0.tar.gz"}
 	downloadedPackages["package3"] = DownloadedPackage{"", "", "Repository2", "/tmp/scribe/downloaded_packages/package_archives/package3_1.0.0.tar.gz"}
+	downloadedPackages["package5"] = DownloadedPackage{"", "", "UndefinedRepository", "/tmp/scribe/downloaded_packages/package_archives/package5_1.2.3.tar.gz"}
 	rRepositories := []Rrepository{
 		{"Repository1", "https://repository1.example.com"},
 		{"Repository2", "https://repository2.example.com"},
 	}
 	getDepsFromPackagesFiles(rPackages, rRepositories, downloadedPackages, packageDependencies,
-		mockedDownloadTextFile)
+		mockedDownloadTextFile, []string{"UndefinedRepository"})
 	assert.Equal(t, packageDependencies["package1"], []string{"package2", "package3"})
 	assert.Equal(t, packageDependencies["package2"], []string{"package3"})
 	assert.Equal(t, len(packageDependencies["package3"]), 0)
 	assert.Equal(t, len(packageDependencies["package4"]), 0)
+	assert.Equal(t, packageDependencies["package5"], []string{"package1"})
 }
 
 func Test_getDepsFromDescriptionFiles(t *testing.T) {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -340,6 +340,7 @@ func installPackages(
 	allInstallInfo *[]InstallResultInfo,
 	additionalBuildOptions string,
 	additionalInstallOptions string,
+	erroneousRepositoryNames []string,
 ) {
 	err := os.MkdirAll(temporaryLibPath, os.ModePerm)
 	checkError(err)
@@ -353,7 +354,8 @@ func installPackages(
 		}
 	}
 
-	dependencies := getPackageDeps(renvLock.Packages, renvLock.R.Repositories, downloadedPackages)
+	dependencies := getPackageDeps(renvLock.Packages, renvLock.R.Repositories,
+		downloadedPackages, erroneousRepositoryNames)
 
 	var installedPackages []string
 	readyPackages := make(map[string]bool)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"time"
 )
 
@@ -394,9 +395,9 @@ package_installation_loop:
 			log.Info(
 				mapTrueLength(readyPackages), " packages ready. ",
 				mapTrueLength(packagesBeingInstalled), " packages being installed. ",
-				len(installedPackages), "/", len(downloadedPackages), " packages processed (",
-				packagesInstalledSuccessfully, " succeeded, ", packagesInstalledUnsuccessfully,
-				" failed).",
+				strconv.Itoa(int(100*float64(len(installedPackages))/float64(len(downloadedPackages)))),
+				"% of packages processed (", packagesInstalledSuccessfully,
+				" succeeded, ", packagesInstalledUnsuccessfully, " failed).",
 			)
 		// Try to run a new package installation.
 		default:

--- a/cmd/renv.go
+++ b/cmd/renv.go
@@ -97,7 +97,9 @@ func validatePackageFields(packageName string, packageFields Rpackage,
 		numberOfWarnings++
 	}
 	if packageFields.Repository == "" {
-		*erroneousRepositoryNames = append(*erroneousRepositoryNames, packageFields.Repository)
+		if !stringInSlice(packageFields.Repository, *erroneousRepositoryNames) {
+			*erroneousRepositoryNames = append(*erroneousRepositoryNames, packageFields.Repository)
+		}
 		switch {
 		case packageFields.Source == "Repository":
 			log.Warn("Package ", packageName, " doesn't have the Repository field set.")
@@ -111,7 +113,9 @@ func validatePackageFields(packageName string, packageFields Rpackage,
 			numberOfWarnings++
 		}
 	} else if !stringInSlice(packageFields.Repository, repositories) {
-		*erroneousRepositoryNames = append(*erroneousRepositoryNames, packageFields.Repository)
+		if !stringInSlice(packageFields.Repository, *erroneousRepositoryNames) {
+			*erroneousRepositoryNames = append(*erroneousRepositoryNames, packageFields.Repository)
+		}
 		log.Warn("Repository \"", packageFields.Repository, "\" has not been defined in lock"+
 			" file for package ", packageName, ".\n")
 		numberOfWarnings++

--- a/cmd/renv.go
+++ b/cmd/renv.go
@@ -78,6 +78,14 @@ func getRenvRepositoryURL(renvLockRepositories []Rrepository, repositoryName str
 	return defaultCranMirrorURL
 }
 
+// appendIfNotInSlice checks whether itemToAppend already exists in slice.
+// If not, it appends itemToAppend to slice.
+func appendIfNotInSlice(itemToAppend string, slice *[]string) {
+	if !stringInSlice(itemToAppend, *slice) {
+		*slice = append(*slice, itemToAppend)
+	}
+}
+
 // validatePackageFields returns the number of warnings occurring during validation of
 // package fields in the renv.lock. If, according to renv.lock, the package should be downloaded
 // from a repository not defined in the renv.lock header, validatePackageFields appends
@@ -97,9 +105,7 @@ func validatePackageFields(packageName string, packageFields Rpackage,
 		numberOfWarnings++
 	}
 	if packageFields.Repository == "" {
-		if !stringInSlice(packageFields.Repository, *erroneousRepositoryNames) {
-			*erroneousRepositoryNames = append(*erroneousRepositoryNames, packageFields.Repository)
-		}
+		appendIfNotInSlice(packageFields.Repository, erroneousRepositoryNames)
 		switch {
 		case packageFields.Source == "Repository":
 			log.Warn("Package ", packageName, " doesn't have the Repository field set.")
@@ -113,9 +119,7 @@ func validatePackageFields(packageName string, packageFields Rpackage,
 			numberOfWarnings++
 		}
 	} else if !stringInSlice(packageFields.Repository, repositories) {
-		if !stringInSlice(packageFields.Repository, *erroneousRepositoryNames) {
-			*erroneousRepositoryNames = append(*erroneousRepositoryNames, packageFields.Repository)
-		}
+		appendIfNotInSlice(packageFields.Repository, erroneousRepositoryNames)
 		log.Warn("Repository \"", packageFields.Repository, "\" has not been defined in lock"+
 			" file for package ", packageName, ".\n")
 		numberOfWarnings++

--- a/cmd/renv.go
+++ b/cmd/renv.go
@@ -174,11 +174,9 @@ func updatePackagesRenvLock(renvLock *Renvlock, outputFilename string, updatedPa
 			if v.RemoteSubdir != "" {
 				remoteSubdir = "/" + v.RemoteSubdir
 			}
-			description, err3 := os.ReadFile(
+			descriptionContents := parseDescriptionFile(
 				localOutputDirectory + "/git_updates/" + k + remoteSubdir + "/DESCRIPTION",
 			)
-			checkError(err3)
-			descriptionContents := parseDescriptionFile(string(description))
 			newPackageVersion := descriptionContents["Version"]
 			// Update renv structure with new package version and SHA.
 			if entry, ok := renvLock.Packages[k]; ok {

--- a/cmd/renv_test.go
+++ b/cmd/renv_test.go
@@ -42,7 +42,9 @@ func Test_getRenvLock(t *testing.T) {
 
 func Test_validateRenvLock(t *testing.T) {
 	var renvLock Renvlock
+	var erroneousRepositoryNames []string
 	getRenvLock("testdata/renv.lock.empty.json", &renvLock)
-	numberOfWarnings := validateRenvLock(renvLock)
+	numberOfWarnings := validateRenvLock(renvLock, &erroneousRepositoryNames)
 	assert.Equal(t, numberOfWarnings, 4)
+	assert.Equal(t, len(erroneousRepositoryNames), 2)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,8 +173,9 @@ for a collection of R packages that are defined in an
 			var renvLock Renvlock
 			var renvLockOld Renvlock
 			var renvLockFilenameOld string
+			var erroneousRepositoryNames []string
 			getRenvLock(renvLockFilename, &renvLock)
-			validateRenvLock(renvLock)
+			validateRenvLock(renvLock, &erroneousRepositoryNames)
 			if updatePackages != "" {
 				renvLockFilenameOld = renvLockFilename
 				renvLockFilename += ".updated"
@@ -210,7 +211,8 @@ for a collection of R packages that are defined in an
 				readJSON(installInfoFile, &allInstallInfo)
 			} else {
 				log.Info(installInfoFile, " doesn't exist.")
-				installPackages(renvLock, &allDownloadInfo, &allInstallInfo, buildOptions, installOptions)
+				installPackages(renvLock, &allDownloadInfo, &allInstallInfo, buildOptions,
+					installOptions, erroneousRepositoryNames)
 			}
 
 			// Perform R CMD check, except when cache contains JSON with previous check results.


### PR DESCRIPTION
In the installation component, package dependencies weren't properly detected for packages which, according to `renv.lock` (typically in the case of `renv.lock` generated by `renv` and not `locksmith`), should be downloaded from package repositories not defined in `renv.lock` header.

The fix addresses this bug by trying to determine dependencies of such packages based on `PACKAGES` file from CRAN.