### PR TITLE
fix: Table footer should be same as header

### DIFF
--- a/cmd/report_template.go
+++ b/cmd/report_template.go
@@ -133,6 +133,7 @@ const HTMLReportTemplate = `<!doctype html>
                     <tr>
                         <th>Name</th>
                         <th>Version</th>
+                        <th>Source</th>
                         <th>Download</th>
                         <th>Build</th>
                         <th>Install</th>


### PR DESCRIPTION
The table footer was off and mismatched the table header.